### PR TITLE
Finished createJWT middleware and defined DB schemas for users, chatlogs and chatrooms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 .idea/
 .vscode/
 .env
+drizzle/
+drizzle.config.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@babel/preset-env": "^7.22.20",
         "@babel/preset-react": "^7.22.15",
         "@types/express": "^4.17.18",
+        "@types/jsonwebtoken": "^9.0.3",
         "@types/node": "^20.8.2",
         "@types/pg": "^8.10.3",
         "babel-loader": "^9.1.3",
@@ -2499,6 +2500,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
       "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
       "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-b0jGiOgHtZ2jqdPgPnP6WLCXZk1T8p06A/vPGzUvxpFGgKMbjXJDjC5m52ErqBnIuWZFgGoIJyRdeG5AyreJjA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-react": "^7.22.15",
     "@types/express": "^4.17.18",
+    "@types/jsonwebtoken": "^9.0.3",
     "@types/node": "^20.8.2",
     "@types/pg": "^8.10.3",
     "babel-loader": "^9.1.3",

--- a/src/server/controllers/jwtControllers.ts
+++ b/src/server/controllers/jwtControllers.ts
@@ -1,0 +1,15 @@
+import jwt from 'jsonwebtoken';
+import {Express, Request, Response, NextFunction} from 'express';
+import dotenv from 'dotenv'; 
+
+dotenv.config(); 
+
+export function createJWT(req: Request, res: Response, next: NextFunction): void {
+  const token = jwt.sign({ userid: res.locals.user.userid }, String(process.env.JWT_SECRET), {expiresIn: 60});
+  res.cookie("jwt", token, {httpOnly: true, secure: true})
+  return next();
+}
+
+export function verifyJWT(req: Request, res: Response, next: NextFunction): void {
+  
+}

--- a/src/server/models/psqlmodels.ts
+++ b/src/server/models/psqlmodels.ts
@@ -1,13 +1,23 @@
-import { pgTable, serial, text, varchar } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, varchar, timestamp } from "drizzle-orm/pg-core";
 
-export const users = pgTable('users', {
-  userid: serial('userid').primaryKey(),
-  username: varchar('username', { length: 20 }),
-  fn: varchar('fn', { length: 20 }),
-  ln: varchar('ln', { length: 20 }),
-  email: varchar('email', { length: 20 }),
-  password: text('password'),
-
+export const users = pgTable("users", {
+	userid: uuid("userid").defaultRandom().primaryKey().notNull(),
+	fn: varchar("fn"),
+	ln: varchar("ln"),
+	email: varchar("email"),
+	password: text("password").notNull(),
+	username: varchar("username").notNull(),
 });
 
-// other postgres tables...
+export const chatrooms = pgTable("chatrooms", {
+	chatroom_id: uuid("chatroom_id").defaultRandom().primaryKey().notNull(),
+	created_at: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	chatroom_name: varchar("chatroom_name"),
+});
+
+export const chatlogs = pgTable("chatlogs", {
+	chatroomId: uuid("chatroom_id").notNull().references(() => chatrooms.chatroom_id),
+	timestamp: timestamp("timestamp", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	message: text("message"),
+	userid: uuid("userid").notNull().references(() => users.userid),
+});

--- a/src/server/routes/api.ts
+++ b/src/server/routes/api.ts
@@ -1,10 +1,11 @@
 import express, { Request, Response } from 'express';
 import { getAllUsers, registerUser, userLogIn, deleteUser, updateUser } from '../controllers/userControllers.js'
+import { createJWT } from '../controllers/jwtControllers.js'
 
 export const router = express.Router();
 
 router.get('/getallusers', getAllUsers, (req: Request, res: Response):void => {res.status(200).json(res.locals.allUsers)});
 router.post('/registeruser', registerUser, (req: Request, res: Response):void => {res.status(200).json('user registered')});
-router.get('/userlogin', userLogIn, (req: Request, res: Response):void => {res.status(200).json(res.locals.user)});
+router.get('/userlogin', userLogIn, createJWT, (req: Request, res: Response):void => {res.status(200).json(res.locals.user)});
 router.delete('/deleteuser', deleteUser, (req: Request, res: Response):void => {res.status(200).json('user deleted')});
 router.patch('/updateuser', userLogIn, updateUser, (req: Request, res: Response):void => {res.status(200).json(res.locals.user)});


### PR DESCRIPTION
**Issue Type**
☐ Bug
☑︎ Feature
☐ Tech Debt

**Description**

0. Created createJWT middleware
1. Put schema generated by drizzle-kit in psqlmodels.ts so that it precisely match the tables 

**Steps to Validate Feature**

0. Run npm run dev to start back end
1. postman GET localhost:3001/api/usersignin with body {"username":"anyusername","password":"anypassword"}, check Headers=>Set-cookie OR click that blue Cookies button near Send.
2. No need to validate schemas since they are generated via actual tables.

Previous behavior
N/A

Expected behavior
Follow steps

Screenshots & Videos
![Screenshot from 2023-10-09 17-42-12](https://github.com/boomonkeyboo/scratch_project/assets/19358126/f6010cb2-3b3b-41aa-a43c-452bddd7d0bd)

Additional context