### PR TITLE
Move socket to module, emit current users in room

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2,20 +2,16 @@ import { Server, Socket } from "socket.io";
 import { createServer } from "http";
 import express from "express";
 import cors from "cors";
-declare module "socket.io" {
-  interface Socket {
-    username: string;
-    room: string;
-  }
-}
 import path from "path";
 import { fileURLToPath } from "url";
 import { router } from "./routes/api.js";
 import { errorHandler } from "./controllers/userControllers.js";
+import { getUsersInRoom } from "./websockets/users.js";
+import * as chatServer from "./websockets/events.js";
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use(cors())
+app.use(cors());
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -27,128 +23,14 @@ const httpServer = createServer(app);
 const io = new Server(httpServer, {
   cors: { origin: "*" },
 });
+chatServer.listen(io);
 
-io.on("connection", (socket) => {
-  /**
-   * Event types:
-   * Client SENDS:
-   * "register" - set socket.username to provided username
-   *    returns "systemMessage" with text
-   * "message" - normal chat messages, default
-   *    returns JSON with {user, message}
-   * "joinRoom"
-   *    returns "systemMessage" with text
-   * "leaveRoom"
-   *    returns "systemMessage" with text
-   *
-   * Client LISTENS:
-   * "message" - a chat message in lobby or room
-   * "systemMessage" - user joins or leaves room
-   */
-
-  socket.username = "anonymous";
-  socket.room = "lobby";
-  console.log(`a user connected with socket id: ${socket.id}`);
-
-  /**
-   * Upon connection, user will join the lobby room by default
-   */
-  // Join room=lobby by default
-  socket.join("lobby");
-  io.to("lobby").emit(
-    "systemMessage",
-    `${socket.id.substring(0, 2)} has joined the lobby`
-  );
-
-  /** Register username
-   * Args:
-   *  1. username - desired display name
-   */
-  socket.on("register", (username: string) => {
-    socket.username = username;
-    console.log(`${socket.id} changed name to ${socket.username}`);
-
-    socket.broadcast
-      .to("lobby")
-      .emit("systemMessage", `${socket.username} has joined the lobby`);
-  });
-
-  /**
-   * User joins a room
-   * Event: "joinRoom"
-   * Request args:
-   *  1. user - user display name
-   *  2. room - name of room to join
-   */
-  // front end
-  // user clicks to join room
-  // 1. websocket request to join room
-  // 2. HTTP fetch request to api route on server, server fetches from db
-  socket.on("joinRoom", (room: string) => {
-    // grab last 20 messages from db for that room
-    // Broadcast to room that a user has joined
-    try {
-      if (!room) {
-        throw Error("No room provided");
-      }
-      // leave lobby or previous room
-      socket.leave(socket.room);
-
-      // join new room
-      socket.room = room;
-      console.log(`${socket.username} has joined ${room}`);
-      socket.join(socket.room);
-
-      // tell room that user has joined
-      socket.broadcast
-        .to(socket.room)
-        .emit(
-          "systemMessage",
-          `socket.broadcast ${socket.username} has joined the chat`
-        );
-    } catch (e) {
-      console.log(e.message);
-    }
-  });
-
-  /**
-   * Chat message
-   * User sends a message to lobby or a specific room
-   * Event: "message"
-   * Args:
-   *  1. message - text of message to send to room
-   *  2. room - optional, room to send message to
-   * Returns: event "message"
-   * Object {
-   *  username: string,
-   *  message: string
-   * }
-   */
-  socket.on("message", (message: string) => {
-    // push message to a database with timestamp and room name
-    console.log(`${socket.username} said ${message}`);
-
-    const response = {
-      username: socket.username,
-      message: message,
-    };
-    // io.to should be used to send messages to all users including self
-    io.to(socket.room).emit("message", response);
-  });
-
-  /**
-   * Leave room
-   * Event: "leaveRoom"
-   * Args:
-   *  1. room - name of room to leave
-   */
-  socket.on("leaveRoom", () => {
-    socket.broadcast
-      .to(socket.room)
-      .emit("systemMessage", `${socket.username} has left the room`);
-    socket.leave(socket.room);
-  });
-});
+declare module "socket.io" {
+  interface Socket {
+    username: string;
+    room: string;
+  }
+}
 
 const PORT = 3001;
 httpServer.listen(PORT, () =>

--- a/src/server/websockets/events.ts
+++ b/src/server/websockets/events.ts
@@ -1,0 +1,141 @@
+import { Server, Socket } from "socket.io";
+import { getUsersInRoom } from "./users.js";
+
+export function listen(io: Server) {
+  io.on("connection", (socket) => {
+    /**
+     * Event types:
+     * Client SENDS:
+     * "register" - set socket.username to provided username
+     *    returns "systemMessage" with text
+     * "message" - normal chat messages, default
+     *    returns JSON with {user, message}
+     * "joinRoom"
+     *    returns "systemMessage" with text
+     * "leaveRoom"
+     *    returns "systemMessage" with text
+     *
+     * Client LISTENS:
+     * "message" - a chat message in lobby or room
+     * "systemMessage" - user joins or leaves room
+     */
+
+    /**
+     * State Variables
+     */
+    socket.username = "anonymous";
+    socket.room = "lobby";
+    console.log(`a user connected with socket id: ${socket.id}`);
+
+    /**
+     * Upon connection, user will join the lobby room by default
+     */
+    // Join room=lobby by default
+    socket.join("lobby");
+    io.to("lobby").emit(
+      "systemMessage",
+      `${socket.id.substring(0, 2)} has joined the lobby`
+    );
+
+    /** Register username
+     * Args:
+     *  1. username - desired display name
+     */
+    socket.on("register", (username: string) => {
+      socket.username = username;
+      console.log(`${socket.id} changed name to ${socket.username}`);
+
+      socket.broadcast
+        .to("lobby")
+        .emit("systemMessage", `${socket.username} has joined the lobby`);
+    });
+
+    /**
+     * User joins a room
+     * Event: "joinRoom"
+     * Request args:
+     *  1. user - user display name
+     *  2. room - name of room to join
+     */
+    // front end
+    // user clicks to join room
+    // 1. websocket request to join room
+    // 2. HTTP fetch request to api route on server, server fetches from db
+    socket.on("joinRoom", async (room: string) => {
+      // grab last 20 messages from db for that room
+      // Broadcast to room that a user has joined
+      try {
+        if (!room) {
+          throw Error("No room provided");
+        }
+        // leave lobby or previous room
+        socket.leave(socket.room);
+        if (socket.room !== "lobby") {
+          const roster = await getUsersInRoom(io, socket);
+          socket.broadcast.to(socket.room).emit("roomUsers", roster);
+        }
+
+        // join new room
+        socket.room = room;
+        console.log(`${socket.username} has joined ${room}`);
+        socket.join(socket.room);
+
+        // tell room that user has joined
+        socket.broadcast
+          .to(socket.room)
+          .emit(
+            "systemMessage",
+            `socket.broadcast ${socket.username} has joined the chat`
+          );
+
+        // send list of connected users in room
+        const roster = await getUsersInRoom(io, socket);
+        io.to(socket.room).emit("roomUsers", roster);
+      } catch (e) {
+        console.log(e.message);
+      }
+    });
+
+    /**
+     * Chat message
+     * User sends a message to lobby or a specific room
+     * Event: "message"
+     * Args:
+     *  1. message - text of message to send to room
+     *  2. room - optional, room to send message to
+     * Returns: event "message"
+     * Object {
+     *  username: string,
+     *  message: string
+     * }
+     */
+    socket.on("message", (message: string) => {
+      // push message to a database with timestamp and room name
+      console.log(`${socket.username} said ${message}`);
+
+      const response = {
+        username: socket.username,
+        message: message,
+      };
+      // io.to should be used to send messages to all users including self
+      io.to(socket.room).emit("message", response);
+    });
+
+    /**
+     * Leave room
+     * Event: "leaveRoom"
+     * Args:
+     *  1. room - name of room to leave
+     */
+    socket.on("leaveRoom", async () => {
+      socket.broadcast
+        .to(socket.room)
+        .emit("systemMessage", `${socket.username} has left the room`);
+      socket.leave(socket.room);
+      // send list of connected users in room
+      console.log(`${socket.username} has left ${socket.room}`);
+      const roster = await getUsersInRoom(io, socket);
+      io.to(socket.room).emit("roomUsers", roster);
+    });
+  });
+}

--- a/src/server/websockets/users.ts
+++ b/src/server/websockets/users.ts
@@ -1,0 +1,9 @@
+import { Server, Socket } from "socket.io";
+
+export async function getUsersInRoom(io: Server, socket: Socket) {
+  const socketsInRoom = await io.in(socket.room).fetchSockets();
+  const roster = socketsInRoom.map((s) => (s as any).username);
+  console.log(`Current users in room ${socket.room}`);
+  console.log(roster);
+  return roster;
+}


### PR DESCRIPTION
## Issue Type
☐ Bug
☑︎ Feature
☑︎ Tech Debt

## Description
### Tech Debt
- `server.ts` was getting bloated with socket.io listeners. Socket.IO logic has been moved into `./server/websockets/events.ts` which is imported into `server.ts` and invoked to start listening.

### Feature
- A new event is emitted `roomUsers` with payload of array of the current usernames in a room. 
- When a user joins a room, `roomUsers` will be emitted to all the users currently in a room.
-  When a user leaves a room or joins a new room, the user is removed from the previous room and `roomUsers` will be emitted to all the users currently in a room
- Current user fetching code is in `./server/websockets/users.ts` 


Steps to Validate Feature
- See #7 on Postman setup
- Add a new listener for `roomUsers`
![image](https://github.com/boomonkeyboo/scratch_project/assets/13823341/eea83d2b-2762-4b46-a53d-b35a291bf91e)


## Previous behavior
- All Socket.IO logic was in main `server.ts` file
- Current list of users was not emitted to client

## Expected behavior
- All previous Socket.IO functionality still works
- List of users in a room is emitted to the room whenever users join or leave a room

## Screenshots
![image](https://github.com/boomonkeyboo/scratch_project/assets/13823341/c90fcf61-c60e-4069-a11a-c509ebb8c1b4)


